### PR TITLE
Get rid of an error message when building the docker containers

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,4 @@ FROM fedora
 RUN dnf -y update
 RUN dnf install python3
 
-ADD ./requirements.txt /root/requirements.txt
-RUN pip3 install -r /root/requirements.txt
-
 WORKDIR /program


### PR DESCRIPTION
@naschidaniel 
Hi Daniel,

If I wanted to build the docker containers I got the following error
 
test123@localhost PythonCodeSnippet]$ python task.py local.rebuild
...
"
Step 5/6 : RUN pip3 install -r /root/requirements.txt
  ---> Running in f7350adf841f
 /bin/sh: pip3: command not found
 Service 'fedora' failed to build: The command '/bin/sh -c pip3 install -r /root/requirements.txt' returned a non-zero code: 127 
"
This is because the requirements.txt - file is empty.

I deleted in the /docker/ - folder
* requirements.txt - file
and edited the 
* Dockerfile

Now it works fine.

Greetings Markus